### PR TITLE
fix: z-index issues in firefox

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -55,7 +55,6 @@
     /* background: theme('colors.black'); */
     box-shadow: -8px 0 0 theme("colors.black");
     position: relative;
-    z-index: 1;
   }
 
   .flowing-title-fancy::before {
@@ -103,6 +102,7 @@
 .hero .hero-image {
   @apply absolute top-0 right-4;
   width: 250px;
+  z-index: -1;
 }
 
 .hero .hero-titles {


### PR DESCRIPTION
On Firefox the `flowing-title-fancy` class is underneath the `flowing-title-fancy:before` which results in the following:

![image](https://user-images.githubusercontent.com/60694691/148063734-77c55563-8c70-4f1d-bf68-d08ea098e968.png)

This pull requests fixes this issue.